### PR TITLE
Change test method name regex to have leading \'test\' be optional

### DIFF
--- a/parser/XcodeTestResultParser.php
+++ b/parser/XcodeTestResultParser.php
@@ -90,7 +90,7 @@ final class XcodeTestResultParser extends ArcanistTestResultParser {
       }
 
       // End of a test.
-      if (!preg_match('/\'-\[.+? test(.+?)\]\' (.+?) \((.+?) seconds\\).$/', $line, $matches)) {
+      if (!preg_match('/\'-\[\S*\s(?:test)*(.+?)\]\' (.+?) \((.+?) seconds\).$/', $line, $matches)) {
         echo "Unable to parse line:\n$line\n";
         continue;
       }


### PR DESCRIPTION
Fixes #3 

Seeing `arc unit` test results now get property parsed for projects using Quick. I am not sure if this works correctly for plain XCUnitTest projects. It should in theory. 
