### PR TITLE
Dynamic config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,42 @@ For example, CocoaPods projects may need to be re-generated.
 
       "pre-build": "pod install --project-directory=path/ --no-repo-update"
 
+### Supporting of multiple test engines
+We support using Arcanist multi test engine extension, visit the [extension]((https://github.com/tagview/arcanist-extensions#multi_test_engine) page to get more information about it.
+
+You `.arcconfig` file will have something similar to the following configuration:
+```
+{
+  "unit.engine": "MultiTestEngine",
+  "unit.engine.multi-test.engines": [
+    {
+      "engine": "XcodeUnitTestEngine",
+      "unit.engine.xcode.config": {
+        "build": {
+          "workspace": "YourWorkSpace.xcworkspace",
+          "scheme": "Scheme1",
+          "configuration": "Debug",
+          "destination": "platform=iOS Simulator,name=iPhone SE"
+        },
+        "coverage": {
+          "product": "SomeFramework.framework/SomeFramework"
+        }
+      }
+    },
+    {
+      "engine": "XcodeUnitTestEngine",
+      "unit.engine.xcode.config": {
+        "build": {
+          "workspace": "YourWorkSpace.xcworkspace",
+          "scheme": "AnotherScheme",
+          "configuration": "Debug"
+        }
+      }
+    }
+  ]
+}
+```
+
 ### Viewing coverage results in Phabricator
 
 Coverage will appear for affected source files in Side-by-Side mode as a colored bar.

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ For example, CocoaPods projects may need to be re-generated.
 
       "pre-build": "pod install --project-directory=path/ --no-repo-update"
 
-### Supporting of multiple test engines
-We support using Arcanist multi test engine extension, visit the [extension]((https://github.com/tagview/arcanist-extensions#multi_test_engine) page to get more information about it.
+### Supporting multiple test engines
 
-You `.arcconfig` file will have something similar to the following configuration:
+We support Arcanist's *multi test engine* extension. Visit the [extension]((https://github.com/tagview/arcanist-extensions#multi_test_engine) page to learn more about it.
+
+Your `.arcconfig` file will have something similar to the following configuration:
+
 ```
 {
   "unit.engine": "MultiTestEngine",

--- a/engine/XcodeUnitTestEngine.php
+++ b/engine/XcodeUnitTestEngine.php
@@ -92,15 +92,16 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
   protected function loadEnvironment() {
     
     $config = $this->readArcConfig();
-
     $unit_config = null;
-    if (array_key_exists('unit.engine.multi-test.engines', $config)) {
-      $config_manager = $this->getConfigurationManager();
-      $unit_config = $config_manager->getConfigFromAnySource('unit.engine.xcode.config');
-    } else {
-      if (array_key_exists('unit.xcode', $config)) {
-        $unit_config = $config['unit.xcode'];
-      }
+
+    $config_manager = $this->getConfigurationManager();
+    if ($config_manager != null) {
+      $unit_config = $config_manager->getConfigFromAnySource('unit.engine.xcode.config');  
+    }
+    
+    if ($unit_config == null && array_key_exists('unit.xcode', $config)) {
+      // falling back to unit.xcode
+      $unit_config = $config['unit.xcode'];
     }
     
     if ($unit_config == null) {

--- a/engine/XcodeUnitTestEngine.php
+++ b/engine/XcodeUnitTestEngine.php
@@ -56,14 +56,12 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
     return ($arcCoverageFlag !== false) && $this->hasCoverageKey;
   }
 
-  private function checkArcConfig() {
-    // Checks if the config file `.arcconfig` exists and in valid JSON format, then return it.
-    // function returns null if something wrong happened.
+  private function checkArcConfigFile() {
+    // Throws exception if the config file `.arcconfig` is missing or it's in invalid JSON format. 
 
     $this->projectRoot = $this->getWorkingCopy()->getProjectRoot();
     $config_path = $this->getWorkingCopy()->getProjectPath('.arcconfig');
 
-    # TODO(featherless): Find a better way to configure the unit engine, possibly via .arcunit.
     if (!Filesystem::pathExists($config_path)) {
       throw new ArcanistUsageException(
         pht(
@@ -74,9 +72,8 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
     }
 
     $data = Filesystem::readFile($config_path);
-    $config = null;
     try {
-      $config = phutil_json_decode($data);
+      phutil_json_decode($data);
     } catch (PhutilJSONParserException $ex) {
       throw new PhutilProxyException(
         pht(
@@ -86,12 +83,11 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
           $config_path),
         $ex);
     }
-    return $config;
   }
 
   protected function loadEnvironment() {
     
-    $this->checkArcConfig();
+    $this->checkArcConfigFile();
 
     $config_manager = $this->getConfigurationManager();
     if ($config_manager == null) {

--- a/engine/XcodeUnitTestEngine.php
+++ b/engine/XcodeUnitTestEngine.php
@@ -92,23 +92,22 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
   protected function loadEnvironment() {
     
     $config = $this->readArcConfig();
-    $unit_config = null;
 
     $config_manager = $this->getConfigurationManager();
-    if ($config_manager != null) {
-      $unit_config = $config_manager->getConfigFromAnySource('unit.engine.xcode.config');  
+    if ($config_manager == null) {
+      throw new ArcanistUsageException(
+        pht(
+          "Unable to setup configuration manager. Make sure that ".
+          "unit.engine is set properly in '%s'",
+          '.arcconfig'));
     }
-    
-    if ($unit_config == null && array_key_exists('unit.xcode', $config)) {
-      // falling back to unit.xcode
-      $unit_config = $config['unit.xcode'];
-    }
+    $unit_config = $config_manager->getConfigFromAnySource('unit.xcode');  
     
     if ($unit_config == null) {
       throw new ArcanistUsageException(
         pht(
-          "Unable to find '%s' neither '%s' keys in .arcconfig.",
-          'unit.xcode', 'unit.engine.multi-test.engines'));
+          "Unable to find '%s' keys in .arcconfig.",
+          'unit.xcode'));
     }
 
     $this->xcodebuild = $unit_config['build'];

--- a/engine/XcodeUnitTestEngine.php
+++ b/engine/XcodeUnitTestEngine.php
@@ -56,7 +56,7 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
     return ($arcCoverageFlag !== false) && $this->hasCoverageKey;
   }
 
-  private function readArcConfig() {
+  private function checkArcConfig() {
     // Checks if the config file `.arcconfig` exists and in valid JSON format, then return it.
     // function returns null if something wrong happened.
 
@@ -91,7 +91,7 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
 
   protected function loadEnvironment() {
     
-    $config = $this->readArcConfig();
+    $this->checkArcConfig();
 
     $config_manager = $this->getConfigurationManager();
     if ($config_manager == null) {


### PR DESCRIPTION
The config key is now dynamically fetched even if it's used with multi test engine
ReadMe file has been updated to indicate that we support [Multi test engine arcanist extension](https://github.com/tagview/arcanist-extensions#multi_test_engine).  and how to use it.