### PR TITLE
Fixing issue in of using wrong path of workspace

### DIFF
--- a/engine/XcodeUnitTestEngine.php
+++ b/engine/XcodeUnitTestEngine.php
@@ -119,6 +119,9 @@ final class XcodeUnitTestEngine extends ArcanistUnitTestEngine {
 
     $xcodeargs = array();
     foreach ($this->xcodebuild as $key => $value) {
+      if ($key == "workspace") {
+        $value = $this->projectRoot."/".$value;
+      } 
       $xcodeargs []= "-$key \"$value\"";
     }
 


### PR DESCRIPTION
fix workspace path if the `arc unit` is called in sub directories. 

#6 